### PR TITLE
GoogleMapのスクロール制御処理追加

### DIFF
--- a/app/_contents/venue.ejs
+++ b/app/_contents/venue.ejs
@@ -14,7 +14,7 @@
       </h4>
       <div class="ui attached segment">
         <div class="googlemap">
-          <iframe src="https://www.google.com/maps/embed?pb=!1m14!1m8!1m3!1d3280.0145877763857!2d135.51358!3d34.704812!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x0%3A0x29b74f158dc09739!2z5aSn6Ziq5aSp5rqA56CU5L-u44K744Oz44K_44O8!5e0!3m2!1sja!2sus!4v1494125705631" width="800" height="600" frameborder="0" style="border:0" allowfullscreen></iframe>
+          <iframe src="https://www.google.com/maps/embed?pb=!1m14!1m8!1m3!1d3280.0145877763857!2d135.51358!3d34.704812!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x0%3A0x29b74f158dc09739!2z5aSn6Ziq5aSp5rqA56CU5L-u44K744Oz44K_44O8!5e0!3m2!1sja!2sus!4v1494125705631" width="800" height="600" frameborder="0" style="border:0" class="mapFrame" allowfullscreen></iframe>
         </div>
       </div>
       ※ 当イベントについて、会場へは問い合わせないようにお願いします。

--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -67,8 +67,23 @@ semantic.ready = function() {
       onBottomPassed: handler.activate.section,
       onTopPassedReverse: handler.activate.previous
     });
-    $('.standard.session.modal')
-      .modal('attach events', '.session.title');
+  $('.standard.session.modal')
+    .modal('attach events', '.session.title');
+
+  var preventScrollingTheMap = function() {
+    var map = $('iframe.mapFrame');
+    //あらかじめiframeにpointer-events:noneを掛け、マウスイベントを無効にしておく
+    map.css('pointer-events', 'none');
+    //一度クリックされたらマウスイベントを有効にする
+    $('.googlemap').click(function() {
+        map.css('pointer-events', 'auto');
+    });
+    //iframeからマウスが離れたら再度pointer-events:noneを効かせる
+    map.mouseout(function() {
+        map.css('pointer-events', 'none');
+    });
+  };
+  preventScrollingTheMap();
 };
 // attach ready event
 $(document).ready(semantic.ready);


### PR DESCRIPTION
現在、サイトをスクロールしていくと途中でGoogleMapが拡縮されて操作性が悪いので、GoogleMapをクリックするまでスクロールが発生しないようにしました。

参考サイト：http://style01.net/528/